### PR TITLE
Fix AWS SES gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-ruby '2.6.6'
+ruby '2.7.6'
 source 'https://rubygems.org'
 
 gem 'aws-ses-v4', '~> 0.8'

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 ruby '2.7.6'
 source 'https://rubygems.org'
 
-gem 'aws-ses-v4', '~> 0.8', :require => 'aws/ses'
+gem 'aws-ses-v4', require: 'aws/ses'
 gem 'activesupport', '~> 6.1'
 gem 'colorize', '~> 0.8'

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 ruby '2.7.6'
 source 'https://rubygems.org'
 
-gem 'aws-ses-v4', '~> 0.8'
+gem 'aws-ses-v4', '~> 0.8', :require => 'aws/ses'
 gem 'activesupport', '~> 6.1'
 gem 'colorize', '~> 0.8'

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 ruby '2.6.6'
 source 'https://rubygems.org'
 
-gem 'aws-ses', '~> 0.7'
+gem 'aws-ses-v4', '~> 0.8'
 gem 'activesupport', '~> 6.1'
 gem 'colorize', '~> 0.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,7 +36,7 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport (~> 6.1)
-  aws-ses-v4 (~> 0.8)
+  aws-ses-v4
   colorize (~> 0.8)
 
 RUBY VERSION

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
-    aws-ses (0.7.1)
+    aws-ses-v4 (0.8.1)
       builder
       mail (> 2.2.5)
       mime-types
@@ -19,14 +19,16 @@ GEM
       concurrent-ruby (~> 1.0)
     mail (2.7.1)
       mini_mime (>= 0.1.1)
-    mime-types (3.3.1)
+    mime-types (3.4.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2020.1104)
-    mini_mime (1.0.2)
+    mime-types-data (3.2022.0105)
+    mini_mime (1.1.2)
     minitest (5.14.2)
+    rexml (3.2.5)
     tzinfo (2.0.3)
       concurrent-ruby (~> 1.0)
-    xml-simple (1.1.5)
+    xml-simple (1.1.9)
+      rexml
     zeitwerk (2.4.2)
 
 PLATFORMS
@@ -34,11 +36,11 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport (~> 6.1)
-  aws-ses (~> 0.7)
+  aws-ses-v4 (~> 0.8)
   colorize (~> 0.8)
 
 RUBY VERSION
-   ruby 2.6.6p146
+   ruby 2.7.6p219
 
 BUNDLED WITH
    2.1.4


### PR DESCRIPTION
We had an AWS SES response error when the monitoring script ran (I had to poke around a bit in an IRB shell with the app environment loaded, as the script normally catches these errors):
`AWS::SES::ResponseError (AWS::SES Response Error: InvalidClientTokenId - Signature Version 3 requests are deprecated from March 1, 2021. From that date on, we are progressively rejecting such requests. To resolve the issue you must migrate to Signature Version 4. If you are self-signing your requests, refer to the documentation for Authenticating requests to the Amazon SES API [1] with Signature Version 4 [2]. If you are not self-signing your requests, simply update your SDK/CLI to the latest version. [1] https://docs.aws.amazon.com/ses/latest/DeveloperGuide/using-ses-api-authentication.html [2] https://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html)
`

We use the `aws-ses-v4` gem in QPixel already, so this just ports the gem over to the uptime script and sets it up.

This code is already running in the Codidact staging instance - the PR is just to ensure the code makes it to the repo.