### PR TITLE
Update ruby version and lockfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-ruby '2.7.6'
+ruby '>= 2.7', '< 4'
 source 'https://rubygems.org'
 
 gem 'aws-ses-v4', require: 'aws/ses'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,7 +40,7 @@ DEPENDENCIES
   colorize (~> 0.8)
 
 RUBY VERSION
-   ruby 2.7.6p219
+   ruby 3.0.0p0
 
 BUNDLED WITH
-   2.1.4
+   2.3.22


### PR DESCRIPTION
There was recently a production outage, and I wondered why the status page was showing all "up"/green status.

After a bit of poking around in relevant systems, it turns out that a ruby upgrade that was implemented broke the uptime monitoring, due to lack of gems under new ruby version/strict ruby version enforcement in Gemfile.

I applied the Gemfile patch here by porting it across from QPixel, and then used bundler to reinstall the right gems under the new ruby version, hence the gem lock file update. After these changes, the system recovered and is now functional.

This patch is being used operationally right now, so this PR is made for transparency purposes.